### PR TITLE
Fix "use of uninitialized value in string ne"

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -66,7 +66,7 @@ my $HOME   = $ENV{HOME};
 my $etcdir = '/etc';
 my ($setting, $value);
 my @config_files = ("$etcdir/colordiffrc");
-if ($ENV{XDG_CONFIG_HOME} ne '') {
+if (defined $ENV{XDG_CONFIG_HOME} && $ENV{XDG_CONFIG_HOME} ne '') {
     push (@config_files, "$ENV{XDG_CONFIG_HOME}/colordiff/colordiffrc")
 }
 elsif (defined $ENV{HOME}) {


### PR DESCRIPTION
$ENV{XDG_CONFIG_HOME} may be uninitialized.  Check if defined before using in string.